### PR TITLE
added sidenav for dashboard

### DIFF
--- a/frontend/src/components/dashboard/RecommendedProblems.tsx
+++ b/frontend/src/components/dashboard/RecommendedProblems.tsx
@@ -27,7 +27,7 @@ const RecommendedProblems = () => {
     };
 
     fetchRecommendedProblems();
-  }, [token]);
+  }, []);
 
   const recommendedProblemItems = useMemo(() => {
     return recommendedProblems.length ? (

--- a/frontend/src/components/dashboard/Sidenav.tsx
+++ b/frontend/src/components/dashboard/Sidenav.tsx
@@ -35,14 +35,14 @@ const Sidenav = ({ navHeadings, navItems }: SidenavProps) => {
           sx={{
             padding: "0.5em 1em",
             paddingRight: "8em",
+            ":hover": {
+              backgroundColor: "rgba(171, 205, 98, 0.2)",
+            },
             bgcolor: idx === value ? "rgba(171, 205, 98, 0.2)" : "transparent",
             color: "#787486",
             justifyContent: "flex-start",
             alignItems: "center",
             gap: 2,
-            ":hover": {
-              backgroundColor: "rgba(171, 205, 98, 0.05)",
-            },
           }}
           disableRipple
           onClick={(e) => handleChange(e, idx)}

--- a/frontend/src/components/dashboard/Sidenav.tsx
+++ b/frontend/src/components/dashboard/Sidenav.tsx
@@ -1,0 +1,85 @@
+import { Button, Stack } from "@mui/material";
+import React, { useMemo, useState } from "react";
+
+interface NavPanelProps {
+  children?: React.ReactNode;
+  index: number;
+  value: number;
+}
+
+const NavPanel = ({ children, value, index }: NavPanelProps) => {
+  return (
+    <div hidden={value !== index} id={`vertical-tabpanel-${index}`}>
+      {value === index && <>{children}</>}
+    </div>
+  );
+};
+
+interface SidenavProps {
+  navHeadings: React.ReactElement[];
+  navItems: React.ReactElement[];
+}
+
+const Sidenav = ({ navHeadings, navItems }: SidenavProps) => {
+  const [value, setValue] = useState(0);
+
+  const handleChange = (event: React.SyntheticEvent, newValue: number) => {
+    setValue(newValue);
+  };
+
+  const navTabItems = useMemo((): React.ReactElement[] => {
+    return navHeadings.map((heading, idx) => {
+      return (
+        <Button
+          key={idx}
+          sx={{
+            padding: "0.5em 1em",
+            paddingRight: "8em",
+            bgcolor: idx === value ? "rgba(171, 205, 98, 0.2)" : "transparent",
+            color: "#787486",
+            justifyContent: "flex-start",
+            alignItems: "center",
+            gap: 2,
+            ":hover": {
+              backgroundColor: "rgba(171, 205, 98, 0.05)",
+            },
+          }}
+          disableRipple
+          onClick={(e) => handleChange(e, idx)}
+        >
+          {heading}
+        </Button>
+      );
+    });
+  }, [navHeadings, value]);
+
+  const navPanelItems = useMemo(() => {
+    return navItems.map((item, idx) => {
+      return (
+        <NavPanel key={idx} value={value} index={idx}>
+          {item}
+        </NavPanel>
+      );
+    });
+  }, [navItems, value]);
+
+  return (
+    <div className="dashboard-sidenav">
+      <Stack
+        sx={{
+          borderRight: 2,
+          padding: "0 1em",
+          borderColor: "divider",
+          display: "flex",
+          justifyContent: "stretch",
+        }}
+      >
+        {navTabItems}
+      </Stack>
+
+      {navPanelItems}
+    </div>
+  );
+};
+
+export default Sidenav;

--- a/frontend/src/pages/Dashboard/DashboardPage.css
+++ b/frontend/src/pages/Dashboard/DashboardPage.css
@@ -1,12 +1,25 @@
 .dashboards-page {
   display: flex;
+  justify-content: flex-start;
+  width: 100vw;
+  position: absolute;
+  left: 0;
+  height: 85%;
+}
+
+.home-page {
+  display: flex;
   flex-direction: column;
   padding: 0 3em;
-  max-width: 1400px;
   margin: auto;
 }
 
-.dashboard-cols {
+.dashboard-sidenav {
+  display: flex;
+  height: 100%;
+}
+
+.home-cols {
   display: flex;
   justify-content: center;
   gap: 1em;
@@ -14,7 +27,7 @@
   flex-wrap: wrap;
 }
 
-.dashboard-col {
+.home-col {
   padding: 1em 2em;
   width: 400px;
   max-width: 400;

--- a/frontend/src/pages/Dashboard/DashboardPage.tsx
+++ b/frontend/src/pages/Dashboard/DashboardPage.tsx
@@ -1,9 +1,11 @@
 import { useLoaderData, json } from "react-router-dom";
-import TopicsList from "../../components/dashboard/TopicsList";
-import RecommendedProblems from "../../components/dashboard/RecommendedProblems";
-import { Typography } from "@mui/material";
 import "./DashboardPage.css";
-import Statistics from "../../components/dashboard/Statistics";
+import Sidenav from "../../components/dashboard/Sidenav";
+import HomePage from "./HomePage";
+import GridViewOutlinedIcon from "@mui/icons-material/GridViewOutlined";
+import { Typography } from "@mui/material";
+import LightbulbOutlinedIcon from "@mui/icons-material/LightbulbOutlined";
+import SettingsOutlinedIcon from "@mui/icons-material/SettingsOutlined";
 
 const BaseURL = import.meta.env.VITE_API_BASE_URL;
 
@@ -21,20 +23,25 @@ interface Topic {
 const DashboardPage = () => {
   const topics = useLoaderData() as Topic[];
 
+  const navItems = [<HomePage topics={topics} />, <div>2 </div>, <div>3 </div>];
+  const navHeadinds = [
+    <>
+      <GridViewOutlinedIcon />
+      <Typography variant="overline">Home</Typography>
+    </>,
+    <>
+      <LightbulbOutlinedIcon />
+      <Typography variant="overline">Learn</Typography>
+    </>,
+    <>
+      <SettingsOutlinedIcon />
+      <Typography variant="overline">Settings</Typography>
+    </>,
+  ];
+
   return (
     <div className="dashboards-page">
-      <Typography variant="h3">Welcome Back</Typography>
-      <div className="dashboard-cols">
-        <div className="dashboard-col">
-          <TopicsList topics={topics} />
-        </div>
-        <div className="dashboard-col">
-          <RecommendedProblems />
-        </div>
-        <div className="dashboard-col">
-          <Statistics />
-        </div>
-      </div>
+      <Sidenav navItems={navItems} navHeadings={navHeadinds} />
     </div>
   );
 };

--- a/frontend/src/pages/Dashboard/HomePage.tsx
+++ b/frontend/src/pages/Dashboard/HomePage.tsx
@@ -1,0 +1,42 @@
+import RecommendedProblems from "../../components/dashboard/RecommendedProblems";
+import Statistics from "../../components/dashboard/Statistics";
+import TopicsList from "../../components/dashboard/TopicsList";
+import { Typography } from "@mui/material";
+
+interface Problem {
+  _id: string;
+  title: string;
+}
+
+interface Topic {
+  _id: string;
+  title: string;
+  problems: Problem[];
+}
+
+interface Props {
+  topics: Topic[];
+}
+
+const HomePage = ({ topics }: Props) => {
+  return (
+    <div className="home-page">
+      <div>
+        <Typography variant="h3">Welcome Back</Typography>
+        <div className="home-cols">
+          <div className="home-col">
+            <TopicsList topics={topics} />
+          </div>
+          <div className="home-col">
+            <RecommendedProblems />
+          </div>
+          <div className="home-col">
+            <Statistics />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default HomePage;


### PR DESCRIPTION
- Added a sidenav for Dashboard Page
- Will add skeletons, transitions and loading states later 
<img width="1685" alt="image" src="https://github.com/UOA-AMEA020-SOFTENG-Projects/technical-interview-webapp/assets/62448681/f5aa4474-8241-4caf-8fb4-d6fa30b21133">


### How to test

1. Comment out the `<LoggedInHeader username={data.username} />` from `pages/HomeRootPage.jsx` 
2. Check if content changes by switching the navbar tabs and styling looks decent for now. 
3. The 'Learn' and 'Settings' page should only display '2' and '3' respectively for now 

