### PR TITLE
Topics styling home page

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -27,6 +27,7 @@
         "react-router-dom": "^6.14.1",
         "react-toastify": "^9.1.3",
         "recharts": "^2.7.2",
+        "styled-components": "^6.1.11",
         "typescript": "^5.4.5"
       },
       "devDependencies": {
@@ -1546,6 +1547,11 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw=="
     },
+    "node_modules/@types/stylis": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.5.tgz",
+      "integrity": "sha512-1Xve+NMN7FWjY14vLoY5tL3BVEQ/n42YLwaqJIPYhotZ9uBHt87VceMwWQpzmdEt2TNXIorIFG+YeCUUW7RInw=="
+    },
     "node_modules/@types/warning": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.0.tgz",
@@ -1838,6 +1844,14 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1946,6 +1960,29 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/css-to-react-native": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+      "dependencies": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^4.0.2"
+      }
+    },
+    "node_modules/css-to-react-native/node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
     "node_modules/css-unit-converter": {
       "version": "1.1.2",
@@ -3492,10 +3529,9 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
-      "dev": true,
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
       "funding": [
         {
           "type": "github",
@@ -3747,8 +3783,7 @@
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "dev": true
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -3762,10 +3797,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.23",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.23.tgz",
-      "integrity": "sha512-bQ3qMcpF6A/YjR55xtoTr0jGOlnPOKAIMdOWiv0EIT6HVPEaJiJB4NLljSbiHoC2RX7DN5Uvjtpbg1NPdwv1oA==",
-      "dev": true,
+      "version": "8.4.38",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
+      "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
       "funding": [
         {
           "type": "opencollective",
@@ -3781,9 +3815,9 @@
         }
       ],
       "dependencies": {
-        "nanoid": "^3.3.6",
+        "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "source-map-js": "^1.2.0"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -4277,6 +4311,11 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -4329,10 +4368,9 @@
       }
     },
     "node_modules/source-map-js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-      "dev": true,
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
+      "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4444,6 +4482,38 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/styled-components": {
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.1.11.tgz",
+      "integrity": "sha512-Ui0jXPzbp1phYij90h12ksljKGqF8ncGx+pjrNPsSPhbUUjWT2tD1FwGo2LF6USCnbrsIhNngDfodhxbegfEOA==",
+      "dependencies": {
+        "@emotion/is-prop-valid": "1.2.2",
+        "@emotion/unitless": "0.8.1",
+        "@types/stylis": "4.2.5",
+        "css-to-react-native": "3.2.0",
+        "csstype": "3.1.3",
+        "postcss": "8.4.38",
+        "shallowequal": "1.1.0",
+        "stylis": "4.3.2",
+        "tslib": "2.6.2"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/styled-components"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0",
+        "react-dom": ">= 16.8.0"
+      }
+    },
+    "node_modules/styled-components/node_modules/stylis": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.2.tgz",
+      "integrity": "sha512-bhtUjWd/z6ltJiQwg0dUfxEJ+W+jdqQd8TbWLWyeIJHlnsqmGLRFFd8e5mA0AZi/zx90smXRlN66YMTcaSFifg=="
+    },
     "node_modules/stylis": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
@@ -4497,9 +4567,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -5694,6 +5764,11 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw=="
     },
+    "@types/stylis": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.5.tgz",
+      "integrity": "sha512-1Xve+NMN7FWjY14vLoY5tL3BVEQ/n42YLwaqJIPYhotZ9uBHt87VceMwWQpzmdEt2TNXIorIFG+YeCUUW7RInw=="
+    },
     "@types/warning": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.0.tgz",
@@ -5912,6 +5987,11 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
     },
+    "camelize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ=="
+    },
     "chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -5989,6 +6069,28 @@
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
+      }
+    },
+    "css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg=="
+    },
+    "css-to-react-native": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+      "requires": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^4.0.2"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+          "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
+        }
       }
     },
     "css-unit-converter": {
@@ -7131,10 +7233,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
-      "dev": true
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g=="
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -7305,8 +7406,7 @@
     "picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "dev": true
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
     },
     "picomatch": {
       "version": "2.3.1",
@@ -7314,14 +7414,13 @@
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
     },
     "postcss": {
-      "version": "8.4.23",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.23.tgz",
-      "integrity": "sha512-bQ3qMcpF6A/YjR55xtoTr0jGOlnPOKAIMdOWiv0EIT6HVPEaJiJB4NLljSbiHoC2RX7DN5Uvjtpbg1NPdwv1oA==",
-      "dev": true,
+      "version": "8.4.38",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
+      "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
       "requires": {
-        "nanoid": "^3.3.6",
+        "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "source-map-js": "^1.2.0"
       }
     },
     "postcss-value-parser": {
@@ -7662,6 +7761,11 @@
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
       "dev": true
     },
+    "shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
+    },
     "shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -7699,10 +7803,9 @@
       "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="
     },
     "source-map-js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-      "dev": true
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
+      "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg=="
     },
     "stack-utils": {
       "version": "2.0.6",
@@ -7783,6 +7886,29 @@
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
     },
+    "styled-components": {
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.1.11.tgz",
+      "integrity": "sha512-Ui0jXPzbp1phYij90h12ksljKGqF8ncGx+pjrNPsSPhbUUjWT2tD1FwGo2LF6USCnbrsIhNngDfodhxbegfEOA==",
+      "requires": {
+        "@emotion/is-prop-valid": "1.2.2",
+        "@emotion/unitless": "0.8.1",
+        "@types/stylis": "4.2.5",
+        "css-to-react-native": "3.2.0",
+        "csstype": "3.1.3",
+        "postcss": "8.4.38",
+        "shallowequal": "1.1.0",
+        "stylis": "4.3.2",
+        "tslib": "2.6.2"
+      },
+      "dependencies": {
+        "stylis": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.2.tgz",
+          "integrity": "sha512-bhtUjWd/z6ltJiQwg0dUfxEJ+W+jdqQd8TbWLWyeIJHlnsqmGLRFFd8e5mA0AZi/zx90smXRlN66YMTcaSFifg=="
+        }
+      }
+    },
     "stylis": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
@@ -7821,9 +7947,9 @@
       }
     },
     "tslib": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "type-check": {
       "version": "0.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,7 @@
     "react-router-dom": "^6.14.1",
     "react-toastify": "^9.1.3",
     "recharts": "^2.7.2",
+    "styled-components": "^6.1.11",
     "typescript": "^5.4.5"
   },
   "devDependencies": {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -12,7 +12,6 @@ import ErrorPage from "./pages/ErrorPage.tsx";
 import RootPage from "./pages/RootPage.jsx";
 import HomeRootPage from "./pages/HomeRootPage.jsx";
 import DashboardPage from "./pages/Dashboard/DashboardPage.tsx";
-import { loader as topicsLoader } from "./pages/Dashboard/DashboardPage.tsx";
 import { loader as problemLoader } from "./pages/ProblemPage.jsx";
 import { loader as contentLoader } from "./pages/ContentPage.jsx";
 import { action as signupAction } from "./pages/SignupPage.jsx";
@@ -43,7 +42,6 @@ const router = createBrowserRouter([
           {
             path: "dashboard",
             element: <DashboardPage />,
-            loader: topicsLoader,
           },
           {
             path: "content/:topicId",

--- a/frontend/src/components/dashboard/Problem.tsx
+++ b/frontend/src/components/dashboard/Problem.tsx
@@ -20,6 +20,9 @@ const fadeIn = keyframes`
 const AnimatedCard = styled(Card)`
   animation: ${fadeIn} 0.5s ease-out forwards;
   opacity: 0;
+  border: none;
+  padding: 0.7em 1em;
+  border-radius: 10px;
 `;
 
 const Problem = ({ problem }: { problem: Problem }) => {
@@ -28,10 +31,7 @@ const Problem = ({ problem }: { problem: Problem }) => {
       to={`/home/problem/${problem._id}`}
       style={{ textDecoration: "none" }}
     >
-      <AnimatedCard
-        variant="outlined"
-        style={{ borderWidth: 0, padding: "0.7em 1em", borderRadius: 10 }}
-      >
+      <AnimatedCard variant="outlined">
         <Typography variant="subtitle1" fontWeight="600" textAlign="left">
           {problem.title}
         </Typography>

--- a/frontend/src/components/dashboard/Problem.tsx
+++ b/frontend/src/components/dashboard/Problem.tsx
@@ -1,10 +1,26 @@
 import { Card, Typography } from "@mui/material";
 import { Link } from "react-router-dom";
+import { keyframes } from "@emotion/react";
+import styled from "@emotion/styled";
 
 interface Problem {
   _id: string;
   title: string;
 }
+
+const fadeIn = keyframes`
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+`;
+
+const AnimatedCard = styled(Card)`
+  animation: ${fadeIn} 0.5s ease-out forwards;
+  opacity: 0;
+`;
 
 const Problem = ({ problem }: { problem: Problem }) => {
   return (
@@ -12,14 +28,14 @@ const Problem = ({ problem }: { problem: Problem }) => {
       to={`/home/problem/${problem._id}`}
       style={{ textDecoration: "none" }}
     >
-      <Card
+      <AnimatedCard
         variant="outlined"
         style={{ borderWidth: 0, padding: "0.7em 1em", borderRadius: 10 }}
       >
         <Typography variant="subtitle1" fontWeight="600" textAlign="left">
           {problem.title}
         </Typography>
-      </Card>
+      </AnimatedCard>
     </Link>
   );
 };

--- a/frontend/src/components/dashboard/TopicsList.tsx
+++ b/frontend/src/components/dashboard/TopicsList.tsx
@@ -4,6 +4,8 @@ import CardContent from "@mui/material/CardContent";
 import { IconButton, Skeleton, Stack, Typography } from "@mui/material";
 import ProblemElement from "./Problem";
 import ArrowBackIosIcon from "@mui/icons-material/ArrowBackIos";
+import { keyframes } from "@emotion/react";
+import styled from "@emotion/styled";
 
 interface Problem {
   _id: string;
@@ -20,6 +22,21 @@ interface Props {
   topics: Topic[];
 }
 
+const fadeIn = keyframes`
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+`;
+
+const AnimatedCard = styled(Card)<{ delay: number }>`
+  animation: ${fadeIn} 0.5s ease-out forwards;
+  animation-delay: ${(props) => props.delay}s;
+  opacity: 0;
+`;
+
 const TopicsList = ({ topics }: Props) => {
   const [showTopics, setShowTopics] = useState(true);
   const [currentTopic, setCurrentTopic] = useState<Topic | null>(null);
@@ -34,7 +51,7 @@ const TopicsList = ({ topics }: Props) => {
   const topicListItems = useMemo(() => {
     return topics.length ? (
       topics.map((topic, index) => (
-        <Card
+        <AnimatedCard
           variant="outlined"
           style={{
             borderRadius: "10px",
@@ -43,6 +60,7 @@ const TopicsList = ({ topics }: Props) => {
           }}
           onClick={() => handleShowQuestionsList(topic)}
           key={index}
+          delay={index * 0.075}
         >
           <CardContent style={{ textAlign: "left", padding: "1em" }}>
             <Typography variant="subtitle1" fontWeight="600">
@@ -59,7 +77,7 @@ const TopicsList = ({ topics }: Props) => {
               ab!
             </Typography>
           </CardContent>
-        </Card>
+        </AnimatedCard>
       ))
     ) : (
       <>

--- a/frontend/src/components/dashboard/TopicsList.tsx
+++ b/frontend/src/components/dashboard/TopicsList.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo } from "react";
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
-import { IconButton, Stack, Typography } from "@mui/material";
+import { IconButton, Skeleton, Stack, Typography } from "@mui/material";
 import ProblemElement from "./Problem";
 import ArrowBackIosIcon from "@mui/icons-material/ArrowBackIos";
 
@@ -32,34 +32,61 @@ const TopicsList = ({ topics }: Props) => {
   };
 
   const topicListItems = useMemo(() => {
-    return topics.map((topic, index) => (
-      <Card
-        variant="outlined"
-        style={{
-          borderRadius: "10px",
-          cursor: "pointer",
-          borderWidth: 0,
-        }}
-        onClick={() => handleShowQuestionsList(topic)}
-        key={index}
-      >
-        <CardContent style={{ textAlign: "left", padding: "1em" }}>
-          <Typography variant="subtitle1" fontWeight="600">
-            {topic.title}
-          </Typography>
-          <Typography
-            variant="body2"
-            lineHeight="1.5"
-            fontSize="0.8rem"
-            fontWeight="300"
-            color="#787486"
+    return topics.length ? (
+      topics.map((topic, index) => (
+        <Card
+          variant="outlined"
+          style={{
+            borderRadius: "10px",
+            cursor: "pointer",
+            borderWidth: 0,
+          }}
+          onClick={() => handleShowQuestionsList(topic)}
+          key={index}
+        >
+          <CardContent style={{ textAlign: "left", padding: "1em" }}>
+            <Typography variant="subtitle1" fontWeight="600">
+              {topic.title}
+            </Typography>
+            <Typography
+              variant="body2"
+              lineHeight="1.5"
+              fontSize="0.8rem"
+              fontWeight="300"
+              color="#787486"
+            >
+              Lorem ipsum dolor sit amet consectetur, adipisicing elit. Quidem,
+              ab!
+            </Typography>
+          </CardContent>
+        </Card>
+      ))
+    ) : (
+      <>
+        {Array.from({ length: 8 }).map((_, index) => (
+          <Card
+            key={index}
+            variant="outlined"
+            style={{
+              borderRadius: "10px",
+              borderWidth: 0,
+            }}
           >
-            Lorem ipsum dolor sit amet consectetur, adipisicing elit. Quidem,
-            ab!
-          </Typography>
-        </CardContent>
-      </Card>
-    ));
+            <CardContent style={{ textAlign: "left", padding: "1em" }}>
+              <Typography variant="subtitle1">
+                <Skeleton animation="wave" />
+              </Typography>
+              <Typography variant="body2">
+                <Skeleton animation="wave" />
+              </Typography>
+              <Typography variant="body2">
+                <Skeleton animation="wave" />
+              </Typography>
+            </CardContent>
+          </Card>
+        ))}
+      </>
+    );
   }, [topics]);
 
   const currentTopicQuestionItems = useMemo(() => {

--- a/frontend/src/components/dashboard/TopicsList.tsx
+++ b/frontend/src/components/dashboard/TopicsList.tsx
@@ -35,6 +35,9 @@ const AnimatedCard = styled(Card)<{ delay: number }>`
   animation: ${fadeIn} 0.5s ease-out forwards;
   animation-delay: ${(props) => props.delay}s;
   opacity: 0;
+  border-radius: 10px;
+  cursor: pointer;
+  border: none;
 `;
 
 const TopicsList = ({ topics }: Props) => {
@@ -53,11 +56,6 @@ const TopicsList = ({ topics }: Props) => {
       topics.map((topic, index) => (
         <AnimatedCard
           variant="outlined"
-          style={{
-            borderRadius: "10px",
-            cursor: "pointer",
-            borderWidth: 0,
-          }}
           onClick={() => handleShowQuestionsList(topic)}
           key={index}
           delay={index * 0.075}

--- a/frontend/src/pages/Dashboard/DashboardPage.tsx
+++ b/frontend/src/pages/Dashboard/DashboardPage.tsx
@@ -1,4 +1,3 @@
-import { useLoaderData, json } from "react-router-dom";
 import "./DashboardPage.css";
 import Sidenav from "../../components/dashboard/Sidenav";
 import HomePage from "./HomePage";
@@ -6,6 +5,7 @@ import GridViewOutlinedIcon from "@mui/icons-material/GridViewOutlined";
 import { Typography } from "@mui/material";
 import LightbulbOutlinedIcon from "@mui/icons-material/LightbulbOutlined";
 import SettingsOutlinedIcon from "@mui/icons-material/SettingsOutlined";
+import { useEffect, useState } from "react";
 
 const BaseURL = import.meta.env.VITE_API_BASE_URL;
 
@@ -21,7 +21,27 @@ interface Topic {
 }
 
 const DashboardPage = () => {
-  const topics = useLoaderData() as Topic[];
+  const [topics, setTopics] = useState<Topic[]>([]);
+
+  useEffect(() => {
+    const fetchTopics = async () => {
+      try {
+        const response = await fetch(`${BaseURL}/topic`);
+
+        if (!response.ok) {
+          console.error("Could not fetch topics: ", response.statusText);
+          return;
+        } else {
+          const data = await response.json();
+          setTopics(data);
+        }
+      } catch (err) {
+        console.error("Could not fetch topics: ", err);
+      }
+    };
+
+    fetchTopics();
+  }, []);
 
   const navItems = [<HomePage topics={topics} />, <div>2 </div>, <div>3 </div>];
   const navHeadinds = [
@@ -47,17 +67,3 @@ const DashboardPage = () => {
 };
 
 export default DashboardPage;
-
-export const loader = async () => {
-  const response = await fetch(`${BaseURL}/topic`);
-
-  if (!response.ok) {
-    const err = await response.json();
-
-    return json({ message: err.message }, { status: 500 });
-  } else {
-    const data = await response.json();
-
-    return data;
-  }
-};

--- a/frontend/src/pages/Dashboard/DashboardPage.tsx
+++ b/frontend/src/pages/Dashboard/DashboardPage.tsx
@@ -42,7 +42,7 @@ const DashboardPage = () => {
 
     const timer = setTimeout(() => {
       fetchTopics();
-    }, 1000);
+    }, 500);
 
     return () => clearTimeout(timer);
   }, []);

--- a/frontend/src/pages/Dashboard/DashboardPage.tsx
+++ b/frontend/src/pages/Dashboard/DashboardPage.tsx
@@ -40,7 +40,11 @@ const DashboardPage = () => {
       }
     };
 
-    fetchTopics();
+    const timer = setTimeout(() => {
+      fetchTopics();
+    }, 1000);
+
+    return () => clearTimeout(timer);
   }, []);
 
   const navItems = [<HomePage topics={topics} />, <div>2 </div>, <div>3 </div>];


### PR DESCRIPTION
### Changes
- Added skeletons as loading state for topics
- Added fade-in animation for the topic cards
- Removed Data loader for Dashboards Page. Loaders fetch the data prior to mounting the component (`DashboardsPage`), allows us display a loading state before mount. Instead of relying on a separate loader, we now fetch data directly within the Dashboards Page using an effect. This allows us to showcase skeletons for the topic cards while rendering the rest of the layout. In my view, this looks much better and makes more sense for such a small fetch request. 

### What to test
- Just the styling and animations for the 'Topics' column on the Home Page. 
- Click into a topic and go back out of it. Try refresh the Home Page

<img width="375" alt="image" src="https://github.com/UOA-AMEA020-SOFTENG-Projects/technical-interview-webapp/assets/62448681/ae4c7420-c2e3-4468-82e3-b2d3f1bfae0b">