### PR TITLE
Heuristics Setup

### DIFF
--- a/backend/models/user.js
+++ b/backend/models/user.js
@@ -13,6 +13,7 @@ const problemAttemptSchema = new mongoose.Schema(
       timeSpent: Number,
       hintUsage: Boolean,
       codeEfficiency: Number, // Representing Big O notation as a number
+      numberOfTestRuns: Number,
     },
     userFeedback: {
       difficulty: {

--- a/frontend/src/components/editor/CodeEditor/CodeEditor.tsx
+++ b/frontend/src/components/editor/CodeEditor/CodeEditor.tsx
@@ -208,6 +208,7 @@ function CodeEditor({ problem }: Props) {
 
     const pipeline = new HeuristicPipeline();
     pipeline.addStrategy(new CorrectnessHeuristic());
+    // We will add more strategies here
 
     const scores = pipeline.execute(metrics);
     const finalScore = combineScores(scores);

--- a/frontend/src/components/editor/CodeEditor/CodeEditor.tsx
+++ b/frontend/src/components/editor/CodeEditor/CodeEditor.tsx
@@ -222,10 +222,12 @@ function CodeEditor({ problem }: Props) {
     clarityValue: number,
     satisfactionValue: number,
   ) => {
+    // We have to %5 because the slider values are from reverted, in SR 5 = perfect resposne,
+    // in our slider 5 is hard
     const userFeedback = new UserFeedback(
-      difficultyValue,
-      clarityValue,
-      satisfactionValue,
+      difficultyValue % 5,
+      clarityValue % 5,
+      satisfactionValue % 5,
     );
 
     // Adjust score based on user feedback - 50% weightage user, heuristic

--- a/frontend/src/heuristics/HeuristicPipeline.ts
+++ b/frontend/src/heuristics/HeuristicPipeline.ts
@@ -12,7 +12,3 @@ export class HeuristicPipeline {
     return this.strategies.map((strategy) => strategy.execute(metrics));
   }
 }
-
-export const combineScores = (scores: number[]): number => {
-  return scores.reduce((a, b) => a + b, 0) / scores.length;
-};

--- a/frontend/src/heuristics/HeuristicPipelint.ts
+++ b/frontend/src/heuristics/HeuristicPipelint.ts
@@ -1,0 +1,18 @@
+import { HeuristicStrategy } from "./HeuristicStrategies";
+import { Metrics } from "./Metrics";
+
+export class HeuristicPipeline {
+  private strategies: HeuristicStrategy[] = [];
+
+  addStrategy(strategy: HeuristicStrategy): void {
+    this.strategies.push(strategy);
+  }
+
+  execute(metrics: Metrics): number[] {
+    return this.strategies.map((strategy) => strategy.execute(metrics));
+  }
+}
+
+export const combineScores = (scores: number[]): number => {
+  return scores.reduce((a, b) => a + b, 0) / scores.length;
+};

--- a/frontend/src/heuristics/HeuristicStrategies.ts
+++ b/frontend/src/heuristics/HeuristicStrategies.ts
@@ -1,0 +1,29 @@
+import { Metrics } from "./Metrics";
+
+export interface HeuristicStrategy {
+  execute(metrics: Metrics): number;
+}
+
+export class TimeSpentHeuristic implements HeuristicStrategy {
+  execute(metrics: Metrics): number {
+    return 0;
+  }
+}
+
+export class CorrectnessHeuristic implements HeuristicStrategy {
+  execute(metrics: Metrics): number {
+    return metrics.correctness && metrics.numberOfTestRuns === 0 ? 5 : 0;
+  }
+}
+
+export class HintUsageHeuristic implements HeuristicStrategy {
+  execute(metrics: Metrics): number {
+    return 0;
+  }
+}
+
+export class CodeEfficiencyHeuristic implements HeuristicStrategy {
+  execute(metrics: Metrics): number {
+    return 0;
+  }
+}

--- a/frontend/src/heuristics/Metrics.ts
+++ b/frontend/src/heuristics/Metrics.ts
@@ -1,0 +1,9 @@
+export class Metrics {
+  constructor(
+    public timeSpent: number,
+    public correctness: boolean,
+    public hintUsage: boolean,
+    public codeEfficiency: number,
+    public numberOfTestRuns: number,
+  ) {}
+}

--- a/frontend/src/heuristics/UserFeedback.ts
+++ b/frontend/src/heuristics/UserFeedback.ts
@@ -1,0 +1,7 @@
+export class UserFeedback {
+  constructor(
+    public difficultyValue: number,
+    public clarityValue: number,
+    public satisfactionValue: number,
+  ) {}
+}

--- a/frontend/src/heuristics/index.ts
+++ b/frontend/src/heuristics/index.ts
@@ -1,0 +1,19 @@
+import { UserFeedback } from "./UserFeedback";
+
+export const combineScores = (scores: number[]): number => {
+  return scores.reduce((a, b) => a + b, 0) / scores.length;
+};
+
+export function adjustScore(
+  heuristicScore: number,
+  userFeedback: UserFeedback,
+  userWeight: number,
+  heuristicWeight: number,
+): number {
+  const averageUserRating =
+    (userFeedback.difficultyValue +
+      userFeedback.clarityValue +
+      userFeedback.satisfactionValue) /
+    3;
+  return heuristicScore * heuristicWeight + averageUserRating * userWeight;
+}


### PR DESCRIPTION
### Changes 
- Setup a new metric `numOfTimesTestsRan` for each submit
- Added a new Heuristics Pipeline to use for executing multiple heuristics. 
- Sending the new metric and calculated quality of response to the DB.
- Adjust the quality of response based on user feedback model giving a weight of 80% to user feedback and 20% to calculated heusitics. 
- We do **NOT** update the measured data for the attempt on running tests, only submitting counts as an attempt. 